### PR TITLE
Set defaults of producer scripts in acq_sim jobs to have TS8 jobnames

### DIFF
--- a/harnessed_jobs/dark_raft_acq_sim/v0/producer_dark_raft_acq_sim.py
+++ b/harnessed_jobs/dark_raft_acq_sim/v0/producer_dark_raft_acq_sim.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 """ Producer script """
-
+import os
 import camera_components
 from simulation.fake_raft import copy_single_sensor_data
 import siteUtils
@@ -8,7 +8,7 @@ import siteUtils
 # These are specific to this test
 TESTTYPE = 'DARK'
 IMGTYPES = ['BIAS', 'DARK']
-PROCESS_NAME_IN = 'vendorIngest'
+PROCESS_NAME_IN = os.environ.get('LCATR_PROCESS_NAME_IN', 'dark_raft_acq')
 PATTERN = '*_dark*.fits'
 OUTPATH = '.'
 RAFT_ID = siteUtils.getUnitId()

--- a/harnessed_jobs/dark_raft_acq_sim/v0/validator_dark_raft_acq_sim.py
+++ b/harnessed_jobs/dark_raft_acq_sim/v0/validator_dark_raft_acq_sim.py
@@ -6,7 +6,7 @@ import lcatr.schema
 import siteUtils
 from simulation import fake_raft
 
-PATTERN = '*_dark*.fits'
+PATTERN = '*_dark*_*.fits'
 OUTPATH = '.'
 JOBNAME = siteUtils.getJobName()
 

--- a/harnessed_jobs/dark_raft_acq_sim/v0/validator_dark_raft_acq_sim.py
+++ b/harnessed_jobs/dark_raft_acq_sim/v0/validator_dark_raft_acq_sim.py
@@ -8,10 +8,10 @@ from simulation import fake_raft
 
 PATTERN = '*_dark*.fits'
 OUTPATH = '.'
-JOB_ID = siteUtils.getJobName()
+JOBNAME = siteUtils.getJobName()
 
 OUTREGEXP = fake_raft.make_outfile_path(outpath=OUTPATH, slot_name="*",
-                                        file_string=PATTERN, job_id=JOB_ID)
+                                        file_string=PATTERN, jobname=JOBNAME)
 
 RESULTS = []
 FILES = sorted(glob.glob(OUTREGEXP))

--- a/harnessed_jobs/fe55_raft_acq_sim/v0/producer_fe55_raft_acq_sim.py
+++ b/harnessed_jobs/fe55_raft_acq_sim/v0/producer_fe55_raft_acq_sim.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 """ Producer script """
-
+import os
 import camera_components
 from simulation.fake_raft import copy_single_sensor_data
 import siteUtils
@@ -8,7 +8,7 @@ import siteUtils
 # These are specific to this test
 TESTTYPE = 'FE55'
 IMGTYPES = ['BIAS', 'FE55']
-PROCESS_NAME_IN = 'vendorIngest'
+PROCESS_NAME_IN = os.environ.get('LCATR_PROCESS_NAME_IN', 'fe55_raft_acq')
 PATTERN = '*_fe55*.fits'
 OUTPATH = '.'
 RAFT_ID = siteUtils.getUnitId()

--- a/harnessed_jobs/fe55_raft_acq_sim/v0/validator_fe55_raft_acq_sim.py
+++ b/harnessed_jobs/fe55_raft_acq_sim/v0/validator_fe55_raft_acq_sim.py
@@ -8,10 +8,10 @@ from simulation import fake_raft
 
 PATTERN = '*_fe55*.fits'
 OUTPATH = '.'
-JOB_ID = siteUtils.getJobName()
+JOBNAME = siteUtils.getJobName()
 
 OUTREGEXP = fake_raft.make_outfile_path(outpath=OUTPATH, slot_name="*",
-                                        file_string=PATTERN, job_id=JOB_ID)
+                                        file_string=PATTERN, jobname=JOBNAME)
 
 RESULTS = []
 FILES = sorted(glob.glob(OUTREGEXP))

--- a/harnessed_jobs/fe55_raft_acq_sim/v0/validator_fe55_raft_acq_sim.py
+++ b/harnessed_jobs/fe55_raft_acq_sim/v0/validator_fe55_raft_acq_sim.py
@@ -6,7 +6,7 @@ import lcatr.schema
 import siteUtils
 from simulation import fake_raft
 
-PATTERN = '*_fe55*.fits'
+PATTERN = '*_fe55*_*.fits'
 OUTPATH = '.'
 JOBNAME = siteUtils.getJobName()
 

--- a/harnessed_jobs/flat_pair_raft_acq_sim/v0/producer_flat_pair_raft_acq_sim.py
+++ b/harnessed_jobs/flat_pair_raft_acq_sim/v0/producer_flat_pair_raft_acq_sim.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 """ Producer script """
-
+import os
 import camera_components
 from simulation.fake_raft import copy_single_sensor_data
 import siteUtils
@@ -8,7 +8,7 @@ import siteUtils
 # These are specific to this test
 TESTTYPE = 'FLAT'
 IMGTYPES = ['FLAT']
-PROCESS_NAME_IN = 'vendorIngest'
+PROCESS_NAME_IN = os.environ.get('LCATR_PROCESS_NAME_IN', 'flat_pair_raft_acq')
 PATTERN = '*_flat*.fits'
 OUTPATH = '.'
 RAFT_ID = siteUtils.getUnitId()

--- a/harnessed_jobs/flat_pair_raft_acq_sim/v0/validator_flat_pair_raft_acq_sim.py
+++ b/harnessed_jobs/flat_pair_raft_acq_sim/v0/validator_flat_pair_raft_acq_sim.py
@@ -8,10 +8,10 @@ from simulation import fake_raft
 
 PATTERN = '*_flat*.fits'
 OUTPATH = '.'
-JOB_ID = siteUtils.getJobName()
+JOBNAME = siteUtils.getJobName()
 
 OUTREGEXP = fake_raft.make_outfile_path(outpath=OUTPATH, slot_name="*",
-                                        file_string=PATTERN, job_id=JOB_ID)
+                                        file_string=PATTERN, jobname=JOBNAME)
 
 RESULTS = []
 FILES = sorted(glob.glob(OUTREGEXP))

--- a/harnessed_jobs/flat_pair_raft_acq_sim/v0/validator_flat_pair_raft_acq_sim.py
+++ b/harnessed_jobs/flat_pair_raft_acq_sim/v0/validator_flat_pair_raft_acq_sim.py
@@ -6,7 +6,7 @@ import lcatr.schema
 import siteUtils
 from simulation import fake_raft
 
-PATTERN = '*_flat*.fits'
+PATTERN = '*_flat*_*.fits'
 OUTPATH = '.'
 JOBNAME = siteUtils.getJobName()
 

--- a/harnessed_jobs/ppump_raft_acq_sim/v0/producer_ppump_raft_acq_sim.py
+++ b/harnessed_jobs/ppump_raft_acq_sim/v0/producer_ppump_raft_acq_sim.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 """ Producer script """
-
+import os
 import camera_components
 from simulation.fake_raft import copy_single_sensor_data
 import siteUtils
@@ -8,7 +8,7 @@ import siteUtils
 # These are specific to this test
 TESTTYPE = 'TRAP'
 IMGTYPES = ['BIAS', 'PPUMP']
-PROCESS_NAME_IN = 'vendorIngest'
+PROCESS_NAME_IN = os.environ.get('LCATR_PROCESS_NAME_IN', 'ppump_raft_acq')
 PATTERN = '*_trap*.fits'
 OUTPATH = '.'
 RAFT_ID = siteUtils.getUnitId()

--- a/harnessed_jobs/ppump_raft_acq_sim/v0/validator_ppump_raft_acq_sim.py
+++ b/harnessed_jobs/ppump_raft_acq_sim/v0/validator_ppump_raft_acq_sim.py
@@ -8,10 +8,10 @@ from simulation import fake_raft
 
 PATTERN = '*_trap*.fits'
 OUTPATH = '.'
-JOB_ID = siteUtils.getJobName()
+JOBNAME = siteUtils.getJobName()
 
 OUTREGEXP = fake_raft.make_outfile_path(outpath=OUTPATH, slot_name="*",
-                                        file_string=PATTERN, job_id=JOB_ID)
+                                        file_string=PATTERN, jobname=JOBNAME)
 
 RESULTS = []
 FILES = sorted(glob.glob(OUTREGEXP))

--- a/harnessed_jobs/ppump_raft_acq_sim/v0/validator_ppump_raft_acq_sim.py
+++ b/harnessed_jobs/ppump_raft_acq_sim/v0/validator_ppump_raft_acq_sim.py
@@ -6,7 +6,7 @@ import lcatr.schema
 import siteUtils
 from simulation import fake_raft
 
-PATTERN = '*_trap*.fits'
+PATTERN = '*_trap*_*.fits'
 OUTPATH = '.'
 JOBNAME = siteUtils.getJobName()
 

--- a/harnessed_jobs/qe_raft_acq_sim/v0/producer_qe_raft_acq_sim.py
+++ b/harnessed_jobs/qe_raft_acq_sim/v0/producer_qe_raft_acq_sim.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 """ Producer script """
-
+import os
 import camera_components
 from simulation.fake_raft import copy_single_sensor_data
 import siteUtils
@@ -8,7 +8,7 @@ import siteUtils
 # These are specific to this test
 TESTTYPE = 'LAMBDA'
 IMGTYPES = ['BIAS', 'FLAT']
-PROCESS_NAME_IN = 'vendorIngest'
+PROCESS_NAME_IN = os.environ.get('LCATR_PROCESS_NAME_ID', 'qe_raft_acq')
 PATTERN = '*_lambda*.fits'
 OUTPATH = '.'
 RAFT_ID = siteUtils.getUnitId()

--- a/harnessed_jobs/qe_raft_acq_sim/v0/validator_qe_raft_acq_sim.py
+++ b/harnessed_jobs/qe_raft_acq_sim/v0/validator_qe_raft_acq_sim.py
@@ -8,10 +8,10 @@ from simulation import fake_raft
 
 PATTERN = '*_lambda*.fits'
 OUTPATH = '.'
-JOB_ID = siteUtils.getJobName()
+JOBNAME = siteUtils.getJobName()
 
 OUTREGEXP = fake_raft.make_outfile_path(outpath=OUTPATH, slot_name="*",
-                                        file_string=PATTERN, job_id=JOB_ID)
+                                        file_string=PATTERN, jobname=JOBNAME)
 
 RESULTS = []
 FILES = sorted(glob.glob(OUTREGEXP))

--- a/harnessed_jobs/qe_raft_acq_sim/v0/validator_qe_raft_acq_sim.py
+++ b/harnessed_jobs/qe_raft_acq_sim/v0/validator_qe_raft_acq_sim.py
@@ -6,7 +6,7 @@ import lcatr.schema
 import siteUtils
 from simulation import fake_raft
 
-PATTERN = '*_lambda*.fits'
+PATTERN = '*_lambda*_*.fits'
 OUTPATH = '.'
 JOBNAME = siteUtils.getJobName()
 

--- a/harnessed_jobs/sflat_raft_acq_sim/v0/producer_sflat_raft_acq_sim.py
+++ b/harnessed_jobs/sflat_raft_acq_sim/v0/producer_sflat_raft_acq_sim.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 """ Producer script """
-
+import os
 import camera_components
 from simulation.fake_raft import copy_single_sensor_data
 import siteUtils
@@ -8,7 +8,7 @@ import siteUtils
 # These are specific to this test
 TESTTYPE = 'SFLAT_500'
 IMGTYPES = ['FLAT']
-PROCESS_NAME_IN = 'vendorIngest'
+PROCESS_NAME_IN = os.environ.get('LCATR_PROCESS_NAME_IN', 'sflat_raft_acq')
 PATTERN = '*_sflat_500*.fits'
 OUTPATH = '.'
 RAFT_ID = siteUtils.getUnitId()

--- a/harnessed_jobs/sflat_raft_acq_sim/v0/validator_sflat_raft_acq_sim.py
+++ b/harnessed_jobs/sflat_raft_acq_sim/v0/validator_sflat_raft_acq_sim.py
@@ -8,10 +8,10 @@ from simulation import fake_raft
 
 PATTERN = '*_sflat_500*.fits'
 OUTPATH = '.'
-JOB_ID = siteUtils.getJobName()
+JOBNAME = siteUtils.getJobName()
 
 OUTREGEXP = fake_raft.make_outfile_path(outpath=OUTPATH, slot_name="*",
-                                        file_string=PATTERN, job_id=JOB_ID)
+                                        file_string=PATTERN, jobname=JOBNAME)
 
 RESULTS = []
 FILES = sorted(glob.glob(OUTREGEXP))

--- a/harnessed_jobs/sflat_raft_acq_sim/v0/validator_sflat_raft_acq_sim.py
+++ b/harnessed_jobs/sflat_raft_acq_sim/v0/validator_sflat_raft_acq_sim.py
@@ -6,7 +6,7 @@ import lcatr.schema
 import siteUtils
 from simulation import fake_raft
 
-PATTERN = '*_sflat_500*.fits'
+PATTERN = '*_sflat_500*_*.fits'
 OUTPATH = '.'
 JOBNAME = siteUtils.getJobName()
 


### PR DESCRIPTION
Also fix the output filenames to conform to LCA-13501, syncing with changes to camera-model (https://github.com/lsst-camera-dh/camera-model/pull/3)