### PR TITLE
aliveness test power-on script changes for REB5s

### DIFF
--- a/harnessed_jobs/rtm_aliveness_power_on/v0/ccs_rtm_aliveness_power_on.py
+++ b/harnessed_jobs/rtm_aliveness_power_on/v0/ccs_rtm_aliveness_power_on.py
@@ -53,6 +53,7 @@ def reb_power_on(ccs_sub, rebid, power_line, ccd_type, raise_exception=True):
     # Power on the REB using the power-up sequence. (10.4.2.2, step 2)
     ccs_sub.rebps.synchCommand(10, 'sequencePower', power_line, True)
 
+    time.sleep(1)
     # Check that the power-supply currents are within the limits
     # for each channel. (10.4.2.2, step 3)
     reb_current_limits.check_rebps_limits(rebid, enforce_lower_limits=False,

--- a/harnessed_jobs/rtm_aliveness_power_on/v0/ccs_rtm_aliveness_power_on.py
+++ b/harnessed_jobs/rtm_aliveness_power_on/v0/ccs_rtm_aliveness_power_on.py
@@ -83,8 +83,8 @@ def reb_power_on(ccs_sub, rebid, power_line, ccd_type, raise_exception=True):
     # there is no reliable way of getting the intended firmware version
     # from the eTraveler, so we just print it to the screen.
     # (10.4.2.2, step 7)
-    logger.info("%s firmware version from CCS: %s", reb_slot,
-                reb_info.hwVersion)
+    logger.info("%s firmware version from CCS: %s (0x%x)", reb_slot,
+                reb_info.hwVersion, reb_info.hwVersion)
 
     # Check that REB P/S currents match the REB currents from ts8
     # within the comparative limits. (10.4.2.2, step 8)

--- a/harnessed_jobs/rtm_aliveness_power_on/v0/ccs_rtm_aliveness_power_on.py
+++ b/harnessed_jobs/rtm_aliveness_power_on/v0/ccs_rtm_aliveness_power_on.py
@@ -69,7 +69,7 @@ def reb_power_on(ccs_sub, rebid, power_line, ccd_type, raise_exception=True):
 
     # The reb_info namedtuple contains the info for the REB in question.
     # That information can be used in the step 6 & 7 tests.
-    reb_info = get_REB_info(ccs_sub.ts8, rebid)
+    reb_info = get_REB_info(ccs_sub.ts8, 220 + rebid)
 
     # Compare the REB hardware serial number to the value in the
     # eTraveler tables for this REB in this raft.  (10.4.2.2, step 6)
@@ -97,7 +97,7 @@ def reb_power_on(ccs_sub, rebid, power_line, ccd_type, raise_exception=True):
     if ccd_type == 'ITL':
         ccs_sub.ts8.synchCommand(10, "loadCategories Rafts:itl")
         ccs_sub.ts8.synchCommand(10, "loadCategories RaftsLimits:itl")
-    elif ccd_type == 'E2V':
+    elif ccd_type.upper() == 'E2V':
         ccs_sub.ts8.synchCommand(10, "loadCategories Rafts:e2v")
         ccs_sub.ts8.synchCommand(10, "loadCategories RaftsLimits:e2v")
     else:

--- a/harnessed_jobs/rtm_aliveness_power_on/v0/ccs_rtm_aliveness_power_on.py
+++ b/harnessed_jobs/rtm_aliveness_power_on/v0/ccs_rtm_aliveness_power_on.py
@@ -55,12 +55,12 @@ def reb_power_on(ccs_sub, rebid, power_line, ccd_type, raise_exception=True):
 
     # Check that the power-supply currents are within the limits
     # for each channel. (10.4.2.2, step 3)
-    reb_current_limits.check_rebps_limits(rebid,
+    reb_current_limits.check_rebps_limits(rebid, enforce_lower_limits=False,
                                           raise_exception=raise_exception)
 
-    # Wait 15 seconds for the FPGA to boot, then check currents again.
+    # Wait 30 seconds for the FPGA to boot, then check currents again.
     # (10.4.2.2, step 4)
-    time.sleep(15)
+    time.sleep(30)
     reb_current_limits.check_rebps_limits(rebid,
                                           raise_exception=raise_exception)
 

--- a/python/rebCurrentLimits.py
+++ b/python/rebCurrentLimits.py
@@ -41,9 +41,10 @@ class RebCurrentLimits(OrderedDict):
         self['ClkHI'] = ChannelLimits('clockhi.IaftLDO', 80., 92., 25.)
         self['ClkLI'] = ChannelLimits('clocklo.IaftLDO', 32., 42., 25.)
         self['ODI'] = ChannelLimits('OD.IaftLDO', 7., 13., 10.)
-        self['HtrI'] = ChannelLimits('heater.IaftLDO', 0., 2., 0.)
+        self['HtrI'] = ChannelLimits('heater.IaftLDO', 0., 15., 0.)
 
-    def check_rebps_limits(self, rebid, raise_exception=True):
+    def check_rebps_limits(self, rebid, enforce_lower_limits=True,
+                           raise_exception=True):
         """
         Check the REB currents at the power supply are within the
         LCA-10064 limits for the specified REB.
@@ -53,6 +54,12 @@ class RebCurrentLimits(OrderedDict):
 
         rebid : int
             ID of the REB to test.
+        enforce_lower_limits : bool [True]
+            Flag to enforce lower limits for each channel.  If False,
+            then the lower limit tests will not be applied.
+        raise_exception: bool [True]
+            Flag to enable exception raising if tested limits are
+            violated.  Disable for testing only.
 
         Raises
         ------
@@ -63,7 +70,8 @@ class RebCurrentLimits(OrderedDict):
             ps_current = self.rebps.synchCommand(10, 'readChannelValue',
                                                  ps_channel_name).getResult()
             self.logger.info("%s: %s mA", ps_channel_name, ps_current)
-            if ps_current < limits.low_lim or ps_current > limits.high_lim:
+            if ((enforce_lower_limits and ps_current < limits.low_lim)
+                or ps_current > limits.high_lim):
                 self.rebps.synchCommand(10, 'sequencePower', rebid, False)
                 message = '%s current out of range. Powering down this REB.' \
                           % ps_channel_name

--- a/python/rebCurrentLimits.py
+++ b/python/rebCurrentLimits.py
@@ -39,7 +39,7 @@ class RebCurrentLimits(OrderedDict):
         self['DigI'] = ChannelLimits('digital.IaftLDO', 430., 650., 100.)
         self['AnaI'] = ChannelLimits('analog.IaftLDO', 530., 615., 50.)
         self['ClkHI'] = ChannelLimits('clockhi.IaftLDO', 80., 92., 25.)
-        self['ClkLI'] = ChannelLimits('clocklo.IaftLDO', 32., 47., 25.)
+        self['ClkLI'] = ChannelLimits('clocklo.IaftLDO', 32., 50., 25.)
         self['ODI'] = ChannelLimits('OD.IaftLDO', 7., 13., 10.)
         self['HtrI'] = ChannelLimits('heater.IaftLDO', 0., 15., 0.)
 

--- a/python/rebCurrentLimits.py
+++ b/python/rebCurrentLimits.py
@@ -36,10 +36,10 @@ class RebCurrentLimits(OrderedDict):
         self.rebps = rebps
         self.ts8 = ts8
         self.logger = rebps.logger
-        self['DigI'] = ChannelLimits('digital.IaftLDO', 500., 650., 100.)
+        self['DigI'] = ChannelLimits('digital.IaftLDO', 430., 650., 100.)
         self['AnaI'] = ChannelLimits('analog.IaftLDO', 530., 615., 50.)
         self['ClkHI'] = ChannelLimits('clockhi.IaftLDO', 80., 92., 25.)
-        self['ClkLI'] = ChannelLimits('clocklo.IaftLDO', 32., 42., 25.)
+        self['ClkLI'] = ChannelLimits('clocklo.IaftLDO', 32., 47., 25.)
         self['ODI'] = ChannelLimits('OD.IaftLDO', 7., 13., 10.)
         self['HtrI'] = ChannelLimits('heater.IaftLDO', 0., 15., 0.)
 


### PR DESCRIPTION
* disable lower limit current checks on REB channels just after power-on
* increase wait time to 30s after FPGA boot for next round of current checks