### PR TITLE
Added dark frame acquisitions to xy_stage_acq

### DIFF
--- a/harnessed_jobs/xy_stage_acq/v0/ccs_xy_stage_acq.py
+++ b/harnessed_jobs/xy_stage_acq/v0/ccs_xy_stage_acq.py
@@ -25,7 +25,7 @@ class XYStageEOAcquisition(XYStageAcquisition):
         self.bcount.
         """
         # Move to initial (xoffset, yoffset) position.
-        self._moveTo(self.xoffset, self.yoffset)     
+        self._moveTo(self.xoffset, self.yoffset)
 
         # Loop over image sequence.
         actuateXed = False

--- a/harnessed_jobs/xy_stage_acq/v0/ccs_xy_stage_acq.py
+++ b/harnessed_jobs/xy_stage_acq/v0/ccs_xy_stage_acq.py
@@ -25,7 +25,7 @@ class XYStageEOAcquisition(XYStageAcquisition):
         self.bcount.
         """
         # Move to initial (xoffset, yoffset) position.
-        self._moveTo(self.xoffset, self.yoffset)
+        self._moveTo(self.xoffset, self.yoffset)     
 
         # Loop over image sequence.
         actuateXed = False
@@ -50,6 +50,9 @@ class XYStageEOAcquisition(XYStageAcquisition):
             for i in range(self.imcount):
                 self.take_image(seqno, exptime, openShutter, actuateXed,
                                 image_type, file_template=file_template)
+            # Take dark frame(s)
+            for i in range(self.dcount):
+                self.dark_image(seqno, exptime)
             # Take bias frame(s).
             for i in range(self.bcount):
                 self.bias_image(seqno)

--- a/python/eo_acquisition.py
+++ b/python/eo_acquisition.py
@@ -359,6 +359,16 @@ class EOAcquisition(object):
         self.take_image(seqno, exptime, openShutter, actuateXed, "BIAS",
                         timeout=150, max_tries=max_tries)
 
+    def dark_image(self, seqno, exptime, max_tries=3):
+        """
+        Take dark image
+        """
+        openShutter = False
+        actuateXed = False
+        timeout = int(max(150, exptime + 20))
+        self.take_image(seqno, exptime, openShutter, actuateXed, "DARK",
+                        timeout=timeout, max_tries=max_tries)
+
     def measured_flux(self, wl, seqno=0, fluxcal_time=2.):
         """
         Compute the measured flux by taking an exposure at the

--- a/python/xy_stage_acquisition.py
+++ b/python/xy_stage_acquisition.py
@@ -22,6 +22,8 @@ class XYStageAcquisition(EOAcquisition):
 
         self.bcount = int(self.eo_config.get('%s_BCOUNT' % acqname.upper(),
                                              default=1))
+        self.dcount = int(self.eo_config.get('%s_DCOUNT' % acqname.upper(),
+                                             default=0))
         self.imcount = int(self.eo_config.get('%s_IMCOUNT' % acqname.upper(),
                                               default=1))
         self.xoffset = float(self.eo_config.get('%s_XOFFSET' % acqname.upper(),


### PR DESCRIPTION
I added the feature to the xy_stage_acq to take a number of dark frames per position, as specified in the config using DCOUNT.  I also added code to the eo_acquisition to take dark frames, similar to the existing bias_image() method.