### PR TITLE
remove setting of db_name option

### DIFF
--- a/harnessed_jobs/rtm_aliveness_exposure/v0/producer_rtm_aliveness_exposure.py
+++ b/harnessed_jobs/rtm_aliveness_exposure/v0/producer_rtm_aliveness_exposure.py
@@ -17,7 +17,7 @@ ccsProducer('rtm_aliveness_exposure', 'ccs_rtm_aliveness_exposure.py',
 raft_id = siteUtils.getUnitId()
 run_number = siteUtils.getRunNumber()
 
-raft = camera_components.Raft.create_from_etrav(raft_id, db_name='Dev')
+raft = camera_components.Raft.create_from_etrav(raft_id)
 results_files = dict()
 bias_files = dict()
 bbox = None


### PR DESCRIPTION
This is a bug that was introduced while testing other changes outside of the eT environment.